### PR TITLE
feat: add feed fetcher and sync

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@mozilla/readability": "^0.6.0",
         "dexie": "^4.0.11",
+        "fast-xml-parser": "^4.4.2",
         "framer-motion": "^12.23.12",
         "react": "^19.1.1",
         "react-dom": "^19.1.1"
@@ -2897,6 +2898,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-xml-parser": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz",
+      "integrity": "sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^1.1.1"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -4306,6 +4325,18 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strnum": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
+      "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/supports-color": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "dexie": "^4.0.11",
     "framer-motion": "^12.23.12",
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "fast-xml-parser": "^4.4.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -5,6 +5,9 @@ export interface Feed {
   url: string;
   title: string;
   folderId?: number | null;
+  etag?: string | null;
+  lastModified?: string | null;
+  lastFetchedAt?: Date | null;
 }
 
 export interface Article {
@@ -35,6 +38,7 @@ export interface SyncLog {
   feedId: number;
   status: string;
   runAt: Date;
+  message?: string;
 }
 
 class AppDB extends Dexie {

--- a/src/lib/feedParser.test.ts
+++ b/src/lib/feedParser.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { parseFeed } from './feedParser.ts';
+
+const rssSample = `<?xml version="1.0"?><rss version="2.0" xmlns:media="http://search.yahoo.com/mrss/"><channel><title>Sample RSS</title><item><title>Item 1</title><link>http://example.com/1</link><pubDate>Mon, 01 Jan 2024 00:00:00 GMT</pubDate><enclosure url="http://example.com/1.jpg" type="image/jpeg"/></item></channel></rss>`;
+
+const atomSample = `<?xml version="1.0"?><feed xmlns="http://www.w3.org/2005/Atom"><title>Sample Atom</title><entry><title>Entry 1</title><link href="http://example.com/a1"/><updated>2024-01-01T00:00:00Z</updated><media:content xmlns:media="http://search.yahoo.com/mrss/" url="http://example.com/a1.png" type="image/png"/></entry></feed>`;
+
+describe('parseFeed', () => {
+  it('parses RSS items', () => {
+    const items = parseFeed(rssSample);
+    expect(items[0].title).toBe('Item 1');
+    expect(items[0].link).toBe('http://example.com/1');
+    expect(items[0].image).toBe('http://example.com/1.jpg');
+  });
+
+  it('parses Atom items', () => {
+    const items = parseFeed(atomSample);
+    expect(items[0].title).toBe('Entry 1');
+    expect(items[0].link).toBe('http://example.com/a1');
+    expect(items[0].image).toBe('http://example.com/a1.png');
+  });
+});

--- a/src/lib/feedParser.ts
+++ b/src/lib/feedParser.ts
@@ -1,0 +1,65 @@
+import { XMLParser } from 'fast-xml-parser';
+
+export interface ParsedItem {
+  title: string;
+  link: string;
+  publishedAt: Date;
+  image?: string;
+}
+
+const parser = new XMLParser({
+  ignoreAttributes: false,
+  attributeNamePrefix: '',
+});
+
+export function parseFeed(xml: string): ParsedItem[] {
+  const json = parser.parse(xml);
+  const items: ParsedItem[] = [];
+
+  if (json.rss && json.rss.channel) {
+    const rssItems = Array.isArray(json.rss.channel.item)
+      ? json.rss.channel.item
+      : json.rss.channel.item
+        ? [json.rss.channel.item]
+        : [];
+    for (const item of rssItems) {
+      const image = item.enclosure?.type?.startsWith('image')
+        ? item.enclosure.url
+        : item['media:content']?.url;
+      items.push({
+        title: item.title ?? '',
+        link: item.link ?? '',
+        publishedAt: item.pubDate ? new Date(item.pubDate) : new Date(),
+        image,
+      });
+    }
+    return items;
+  }
+
+  if (json.feed) {
+    const entries = Array.isArray(json.feed.entry)
+      ? json.feed.entry
+      : json.feed.entry
+        ? [json.feed.entry]
+        : [];
+    for (const entry of entries) {
+      const link =
+        typeof entry.link === 'string' ? entry.link : entry.link?.href;
+      const image = entry.enclosure?.type?.startsWith('image')
+        ? entry.enclosure.url
+        : entry['media:content']?.url;
+      items.push({
+        title: entry.title ?? '',
+        link: link ?? '',
+        publishedAt: entry.updated
+          ? new Date(entry.updated)
+          : entry.published
+            ? new Date(entry.published)
+            : new Date(),
+        image,
+      });
+    }
+  }
+
+  return items;
+}

--- a/src/lib/fetcher.ts
+++ b/src/lib/fetcher.ts
@@ -1,0 +1,69 @@
+export interface FetchFeedOptions {
+  etag?: string | null;
+  lastModified?: string | null;
+  proxy?: string | null;
+  retries?: number;
+}
+
+function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Fetch a URL with optional retry/backoff and proxy support. If `etag` or
+ * `lastModified` are provided, conditional requests will be made. When a
+ * request fails due to network/CORS, the optional `proxy` URL is used on the
+ * next attempt.
+ */
+export async function fetchFeed(
+  url: string,
+  { etag, lastModified, proxy, retries = 3 }: FetchFeedOptions = {},
+): Promise<{
+  status: number;
+  etag?: string;
+  lastModified?: string;
+  text?: string;
+}> {
+  const headers = new Headers();
+  if (etag) headers.set('If-None-Match', etag);
+  if (lastModified) headers.set('If-Modified-Since', lastModified);
+
+  let attempt = 0;
+  let useProxy = false;
+  let lastError: unknown;
+
+  while (attempt < retries) {
+    const target =
+      useProxy && proxy ? `${proxy}?url=${encodeURIComponent(url)}` : url;
+    try {
+      const res = await fetch(target, { headers });
+      // Retry on server errors
+      if (res.status >= 500 && attempt < retries - 1) {
+        attempt++;
+        await delay(2 ** attempt * 500);
+        continue;
+      }
+      if (res.status === 304) {
+        return { status: 304 };
+      }
+      const text = await res.text();
+      return {
+        status: res.status,
+        etag: res.headers.get('etag') ?? undefined,
+        lastModified: res.headers.get('last-modified') ?? undefined,
+        text,
+      };
+    } catch (err) {
+      lastError = err;
+      if (!useProxy && proxy) {
+        // try again using proxy
+        useProxy = true;
+      } else {
+        attempt++;
+        if (attempt >= retries) break;
+        await delay(2 ** attempt * 500);
+      }
+    }
+  }
+  throw lastError instanceof Error ? lastError : new Error('Failed to fetch');
+}

--- a/src/lib/sync.ts
+++ b/src/lib/sync.ts
@@ -1,0 +1,76 @@
+import { fetchFeed } from './fetcher.ts';
+import { parseFeed } from './feedParser.ts';
+import {
+  articlesRepo,
+  feedsRepo,
+  settingsRepo,
+  syncLogRepo,
+} from './repositories/index.ts';
+
+let timer: ReturnType<typeof setInterval> | null = null;
+
+export async function syncFeedsOnce() {
+  const proxySetting = await settingsRepo.get('proxyUrl');
+  const proxy = proxySetting?.value ?? null;
+  const feeds = await feedsRepo.all();
+  for (const feed of feeds) {
+    try {
+      const res = await fetchFeed(feed.url, {
+        etag: feed.etag,
+        lastModified: feed.lastModified,
+        proxy,
+      });
+      if (res.status === 304) {
+        await feedsRepo.update(feed.id!, { lastFetchedAt: new Date() });
+        await syncLogRepo.add({
+          feedId: feed.id!,
+          status: 'not-modified',
+          runAt: new Date(),
+        });
+        continue;
+      }
+      if (res.text) {
+        const items = parseFeed(res.text);
+        for (const item of items) {
+          await articlesRepo.add({
+            feedId: feed.id!,
+            title: item.title,
+            link: item.link,
+            publishedAt: item.publishedAt,
+          });
+        }
+      }
+      await feedsRepo.update(feed.id!, {
+        etag: res.etag ?? null,
+        lastModified: res.lastModified ?? null,
+        lastFetchedAt: new Date(),
+      });
+      await syncLogRepo.add({
+        feedId: feed.id!,
+        status: 'ok',
+        runAt: new Date(),
+      });
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      await syncLogRepo.add({
+        feedId: feed.id!,
+        status: 'error',
+        message,
+        runAt: new Date(),
+      });
+    }
+  }
+}
+
+export async function scheduleSync() {
+  const intervalSetting = await settingsRepo.get('syncEveryMinutes');
+  const minutes = parseInt(intervalSetting?.value ?? '30', 10);
+  if (timer) clearInterval(timer);
+  timer = setInterval(syncFeedsOnce, minutes * 60 * 1000);
+  await syncFeedsOnce();
+}
+
+export function stopSync() {
+  if (timer) clearInterval(timer);
+  timer = null;
+}


### PR DESCRIPTION
## Summary
- add feed fetching utility with retry, caching headers and proxy fallback
- parse RSS/Atom feeds using fast-xml-parser
- schedule periodic sync and record results

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a071fdf4e8833288b24b6043513dcd