### PR TITLE
Fix lint warnings and TypeScript build errors

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,6 +1,6 @@
 import { Button } from '../components';
 import { FeedListPage } from '../features/feeds/FeedListPage';
-import { useTheme } from '../theme/ThemeProvider';
+import { useTheme } from '../theme/theme';
 
 function App() {
   const { theme, setTheme } = useTheme();

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,4 +1,4 @@
-import { ButtonHTMLAttributes } from 'react';
+import type { ButtonHTMLAttributes } from 'react';
 import './Button.css';
 
 export function Button({

--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -1,4 +1,4 @@
-import { HTMLAttributes } from 'react';
+import type { HTMLAttributes } from 'react';
 import './EmptyState.css';
 
 interface Props extends HTMLAttributes<HTMLDivElement> {

--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -1,4 +1,4 @@
-import { ButtonHTMLAttributes } from 'react';
+import type { ButtonHTMLAttributes } from 'react';
 import './IconButton.css';
 
 export function IconButton({

--- a/src/components/ListItem.tsx
+++ b/src/components/ListItem.tsx
@@ -1,4 +1,4 @@
-import { HTMLAttributes } from 'react';
+import type { HTMLAttributes } from 'react';
 import './ListItem.css';
 
 export function ListItem({

--- a/src/components/Panel.tsx
+++ b/src/components/Panel.tsx
@@ -1,4 +1,4 @@
-import { HTMLAttributes } from 'react';
+import type { HTMLAttributes } from 'react';
 import './Panel.css';
 
 export function Panel({ children, ...props }: HTMLAttributes<HTMLDivElement>) {

--- a/src/features/feeds/FeedListPage.tsx
+++ b/src/features/feeds/FeedListPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Button, ListItem, Panel } from '../../components';
-import { db, Feed } from '../../lib/db';
+import { db } from '../../lib/db';
+import type { Feed } from '../../lib/db';
 import { discoverFeed } from '../../lib/discoverFeed';
 import { importOpml, exportOpml } from '../../lib/opml';
 import { useDexieLiveQuery } from '../../hooks/useDexieLiveQuery';

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,4 +1,4 @@
-import Dexie, { Table } from 'dexie';
+import Dexie, { type Table } from 'dexie';
 
 export interface Feed {
   id?: number;

--- a/src/lib/opml.ts
+++ b/src/lib/opml.ts
@@ -1,4 +1,5 @@
-import { db, Feed, Folder } from './db';
+import { db } from './db';
+import type { Feed, Folder } from './db';
 import { normalizeUrl } from './normalizeUrl';
 
 export interface ParsedFeed {

--- a/src/theme/ThemeProvider.tsx
+++ b/src/theme/ThemeProvider.tsx
@@ -1,25 +1,7 @@
-/* eslint react-refresh/only-export-components: warn */
-import {
-  createContext,
-  useContext,
-  useEffect,
-  useRef,
-  useState,
-  ReactNode,
-} from 'react';
+import { useEffect, useRef, useState, type ReactNode } from 'react';
 import { db } from '../lib/db';
-
-export type Theme = 'light' | 'dark';
-
-interface ThemeContextValue {
-  theme: Theme;
-  setTheme: (theme: Theme) => void;
-}
-
-const ThemeContext = createContext<ThemeContextValue>({
-  theme: 'light',
-  setTheme: () => {},
-});
+import { ThemeContext } from './theme';
+import type { Theme } from './theme';
 
 export function ThemeProvider({ children }: { children: ReactNode }) {
   const [theme, setThemeState] = useState<Theme>('light');
@@ -63,8 +45,4 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
       {children}
     </ThemeContext.Provider>
   );
-}
-
-export function useTheme() {
-  return useContext(ThemeContext);
 }

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -1,0 +1,17 @@
+import { createContext, useContext } from 'react';
+
+export type Theme = 'light' | 'dark';
+
+export interface ThemeContextValue {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+}
+
+export const ThemeContext = createContext<ThemeContextValue>({
+  theme: 'light',
+  setTheme: () => {},
+});
+
+export function useTheme() {
+  return useContext(ThemeContext);
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 
 // https://vite.dev/config/


### PR DESCRIPTION
## Summary
- move theme context and hook into their own module
- adjust imports for TypeScript `verbatimModuleSyntax`
- use vitest config for `test` options

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a07563524883329c60e4e2358a6d42