### PR TITLE
feat: center main image in reader with pan zoom

### DIFF
--- a/src/features/reader/ReaderPage.css
+++ b/src/features/reader/ReaderPage.css
@@ -1,0 +1,23 @@
+.reader-image-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 80vh;
+  overflow: hidden;
+  touch-action: none;
+}
+
+.reader-image-container img {
+  max-width: 100%;
+  max-height: 100%;
+  transform-origin: center;
+  cursor: grab;
+  transition: transform 0.2s ease-out;
+}
+
+.reader-image-alt {
+  margin-top: var(--spacing-sm);
+  text-align: center;
+  font-style: italic;
+}

--- a/src/features/reader/ReaderPage.tsx
+++ b/src/features/reader/ReaderPage.tsx
@@ -2,6 +2,8 @@ import { useParams } from 'react-router-dom';
 import { Button, Panel } from '../../components';
 import { db } from '../../lib/db';
 import { useDexieLiveQuery } from '../../hooks/useDexieLiveQuery';
+import { usePanZoom } from '../../hooks/usePanZoom';
+import './ReaderPage.css';
 
 export function ReaderPage() {
   const { articleId } = useParams();
@@ -14,11 +16,22 @@ export function ReaderPage() {
     return { article, feed };
   }, [articleId]);
 
+  const panZoom = usePanZoom();
+
   if (!data?.article || !data.feed) {
     return <Panel>Article not found</Panel>;
   }
 
   const { article, feed } = data;
+  const {
+    containerRef,
+    scale,
+    offset,
+    handleWheel,
+    handlePointerDown,
+    handlePointerMove,
+    handlePointerUp,
+  } = panZoom;
 
   const handleOpenOriginal = () => {
     window.open(article.link, '_blank');
@@ -34,6 +47,28 @@ export function ReaderPage() {
       <p>
         {feed.title} – {article.publishedAt.toLocaleDateString()}
       </p>
+      {article.mainImageUrl && (
+        <div
+          className="reader-image-container"
+          ref={containerRef}
+          onWheel={handleWheel}
+          onPointerDown={handlePointerDown}
+          onPointerMove={handlePointerMove}
+          onPointerUp={handlePointerUp}
+          onPointerLeave={handlePointerUp}
+        >
+          <img
+            src={article.mainImageUrl}
+            alt={article.mainImageAlt ?? ''}
+            style={{
+              transform: `translate(${offset.x}px, ${offset.y}px) scale(${scale})`,
+            }}
+          />
+        </div>
+      )}
+      {article.mainImageAlt && (
+        <p className="reader-image-alt">{article.mainImageAlt}</p>
+      )}
       <Button onClick={handleOpenOriginal}>Open Original</Button>
       <Button onClick={handleMarkUnread}>Mark Unread</Button>
     </Panel>

--- a/src/hooks/usePanZoom.ts
+++ b/src/hooks/usePanZoom.ts
@@ -1,0 +1,50 @@
+import { useRef, useState } from 'react';
+
+export function usePanZoom() {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [scale, setScale] = useState(1);
+  const [offset, setOffset] = useState({ x: 0, y: 0 });
+
+  const handleWheel = (e: React.WheelEvent) => {
+    e.preventDefault();
+    const delta = -e.deltaY / 500;
+    setScale((s) => {
+      const next = Math.min(3, Math.max(1, s + delta));
+      if (next === 1) {
+        setOffset({ x: 0, y: 0 });
+      }
+      return next;
+    });
+  };
+
+  const lastPos = useRef<{ x: number; y: number } | null>(null);
+
+  const handlePointerDown = (e: React.PointerEvent) => {
+    if (scale === 1) return;
+    lastPos.current = { x: e.clientX, y: e.clientY };
+    (e.target as HTMLElement).setPointerCapture(e.pointerId);
+  };
+
+  const handlePointerMove = (e: React.PointerEvent) => {
+    if (!lastPos.current) return;
+    setOffset((o) => ({
+      x: o.x + e.clientX - lastPos.current!.x,
+      y: o.y + e.clientY - lastPos.current!.y,
+    }));
+    lastPos.current = { x: e.clientX, y: e.clientY };
+  };
+
+  const handlePointerUp = () => {
+    lastPos.current = null;
+  };
+
+  return {
+    containerRef,
+    scale,
+    offset,
+    handleWheel,
+    handlePointerDown,
+    handlePointerMove,
+    handlePointerUp,
+  };
+}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -16,6 +16,8 @@ export interface Article {
   title: string;
   link: string;
   publishedAt: Date;
+  mainImageUrl?: string | null;
+  mainImageAlt?: string | null;
 }
 
 export interface ReadState {


### PR DESCRIPTION
## Summary
- center main image with flex container and optional pan/zoom
- add fit-to-width styles and alt text support

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a089f8e3f4833294e79978f670523d