### PR TITLE
Display image caption from alt or title in ReaderPage

### DIFF
--- a/src/features/reader/ReaderPage.css
+++ b/src/features/reader/ReaderPage.css
@@ -15,9 +15,3 @@
   cursor: grab;
   transition: transform 0.2s ease-out;
 }
-
-.reader-image-alt {
-  margin-top: var(--spacing-sm);
-  text-align: center;
-  font-style: italic;
-}

--- a/src/features/reader/ReaderPage.tsx
+++ b/src/features/reader/ReaderPage.tsx
@@ -1,9 +1,11 @@
+import { useState, type SyntheticEvent } from 'react';
 import { useParams } from 'react-router-dom';
 import { Button, Panel } from '../../components';
 import { db } from '../../lib/db';
 import { useDexieLiveQuery } from '../../hooks/useDexieLiveQuery';
 import { usePanZoom } from '../../hooks/usePanZoom';
 import './ReaderPage.css';
+import '../../styles/caption.css';
 
 export function ReaderPage() {
   const { articleId } = useParams();
@@ -17,6 +19,7 @@ export function ReaderPage() {
   }, [articleId]);
 
   const panZoom = usePanZoom();
+  const [caption, setCaption] = useState('');
 
   if (!data?.article || !data.feed) {
     return <Panel>Article not found</Panel>;
@@ -41,6 +44,12 @@ export function ReaderPage() {
     await db.readState.put({ articleId: article.id!, read: false });
   };
 
+  const handleImageLoad = (e: SyntheticEvent<HTMLImageElement>) => {
+    const img = e.currentTarget;
+    const text = img.getAttribute('alt') || img.getAttribute('title') || '';
+    setCaption(text);
+  };
+
   return (
     <Panel>
       <h1>{article.title}</h1>
@@ -48,7 +57,7 @@ export function ReaderPage() {
         {feed.title} – {article.publishedAt.toLocaleDateString()}
       </p>
       {article.mainImageUrl && (
-        <div
+        <figure
           className="reader-image-container"
           ref={containerRef}
           onWheel={handleWheel}
@@ -60,14 +69,13 @@ export function ReaderPage() {
           <img
             src={article.mainImageUrl}
             alt={article.mainImageAlt ?? ''}
+            onLoad={handleImageLoad}
             style={{
               transform: `translate(${offset.x}px, ${offset.y}px) scale(${scale})`,
             }}
           />
-        </div>
-      )}
-      {article.mainImageAlt && (
-        <p className="reader-image-alt">{article.mainImageAlt}</p>
+          {caption && <figcaption className="caption">{caption}</figcaption>}
+        </figure>
       )}
       <Button onClick={handleOpenOriginal}>Open Original</Button>
       <Button onClick={handleMarkUnread}>Mark Unread</Button>

--- a/src/styles/caption.css
+++ b/src/styles/caption.css
@@ -1,0 +1,8 @@
+/* Caption styling for images */
+.caption {
+  margin-top: var(--spacing-sm);
+  text-align: center;
+  font-style: italic;
+  color: var(--color-muted);
+  font-size: var(--text-sm);
+}


### PR DESCRIPTION
## Summary
- capture alt or title text of main image on load and render below image
- style captions with shared CSS for subtle presentation

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0952397ec8332b6b3d6e67153f1b8