### PR TITLE
Add DOMPurify sanitization for article content

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@mozilla/readability": "^0.6.0",
         "dexie": "^4.0.11",
+        "dompurify": "^3.0.11",
         "fast-xml-parser": "^4.4.2",
         "framer-motion": "^12.23.12",
         "react": "^19.1.1",
@@ -2475,6 +2476,12 @@
       "resolved": "https://registry.npmjs.org/dexie/-/dexie-4.0.11.tgz",
       "integrity": "sha512-SOKO002EqlvBYYKQSew3iymBoN2EQ4BDw/3yprjh7kAfFzjBYkaMNa/pZvcA7HSWlcKSQb9XhPe3wKyQ0x4A8A==",
       "license": "Apache-2.0"
+    },
+    "node_modules/dompurify": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.0.11.tgz",
+      "integrity": "sha512-Fan4uMuyB26gFV3ovPoEoQbxRRPfTu3CvImyZnhGq5fsIEO+gEFLp45ISFt+kQBWsK5ulDdT0oV28jS1UrwQLg==",
+      "license": "(MPL-2.0 OR Apache-2.0)"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.203",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@mozilla/readability": "^0.6.0",
     "dexie": "^4.0.11",
+    "dompurify": "^3.0.11",
     "fast-xml-parser": "^4.4.2",
     "framer-motion": "^12.23.12",
     "react": "^19.1.1",

--- a/src/features/reader/ReaderPage.tsx
+++ b/src/features/reader/ReaderPage.tsx
@@ -2,6 +2,7 @@ import { useState, type SyntheticEvent } from 'react';
 import { useParams } from 'react-router-dom';
 import { Button, Panel } from '../../components';
 import { db } from '../../lib/db';
+import { sanitize } from '../../lib/sanitize';
 import { useDexieLiveQuery } from '../../hooks/useDexieLiveQuery';
 import { usePanZoom } from '../../hooks/usePanZoom';
 import './ReaderPage.css';
@@ -50,6 +51,10 @@ export function ReaderPage() {
     setCaption(text);
   };
 
+  const sanitizedHtml = article.contentHtml
+    ? sanitize(article.contentHtml)
+    : null;
+
   return (
     <Panel>
       <h1>{article.title}</h1>
@@ -76,6 +81,12 @@ export function ReaderPage() {
           />
           {caption && <figcaption className="caption">{caption}</figcaption>}
         </figure>
+      )}
+      {sanitizedHtml && (
+        <div
+          className="reader-content"
+          dangerouslySetInnerHTML={{ __html: sanitizedHtml }}
+        />
       )}
       <Button onClick={handleOpenOriginal}>Open Original</Button>
       <Button onClick={handleMarkUnread}>Mark Unread</Button>

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -18,6 +18,7 @@ export interface Article {
   publishedAt: Date;
   mainImageUrl?: string | null;
   mainImageAlt?: string | null;
+  contentHtml?: string | null;
 }
 
 export interface ReadState {

--- a/src/lib/sanitize.ts
+++ b/src/lib/sanitize.ts
@@ -1,0 +1,5 @@
+import DOMPurify from 'dompurify';
+
+export function sanitize(html: string): string {
+  return DOMPurify.sanitize(html);
+}


### PR DESCRIPTION
## Summary
- include DOMPurify to sanitize article HTML
- add helper to sanitize HTML and render sanitized content in ReaderPage
- extend Article model with optional `contentHtml`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a097ac83248332a63fc81743f1520d