### PR TITLE
feat: add readability worker and query helper

### DIFF
--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -9,3 +9,40 @@ export async function getUnreadCount(feedId: number): Promise<number> {
   const readCount = states.filter((s) => s?.read).length;
   return articleIds.length - readCount;
 }
+
+let readabilityWorker: Worker | undefined;
+
+export async function fetchReadableHtml(url: string): Promise<string | null> {
+  return new Promise((resolve, reject) => {
+    if (!readabilityWorker) {
+      readabilityWorker = new Worker(
+        new URL('./readabilityWorker.ts', import.meta.url),
+        { type: 'module' },
+      );
+    }
+
+    const worker = readabilityWorker;
+
+    const onMessage = (
+      event: MessageEvent<{ html: string | null; error?: string }>,
+    ) => {
+      worker.removeEventListener('message', onMessage);
+      worker.removeEventListener('error', onError);
+      if (event.data.error) {
+        reject(new Error(event.data.error));
+      } else {
+        resolve(event.data.html);
+      }
+    };
+
+    const onError = (err: ErrorEvent) => {
+      worker.removeEventListener('message', onMessage);
+      worker.removeEventListener('error', onError);
+      reject(err);
+    };
+
+    worker.addEventListener('message', onMessage);
+    worker.addEventListener('error', onError);
+    worker.postMessage(url);
+  });
+}

--- a/src/lib/readabilityWorker.ts
+++ b/src/lib/readabilityWorker.ts
@@ -1,0 +1,26 @@
+import { Readability } from '@mozilla/readability';
+import { parseHTML } from 'linkedom';
+import createDOMPurify from 'dompurify';
+
+self.onmessage = async (event: MessageEvent<string>) => {
+  try {
+    const url = event.data;
+    const res = await fetch(url);
+    const html = await res.text();
+    const { document, window } = parseHTML(html);
+    const reader = new Readability(document);
+    const article = reader.parse();
+
+    if (article?.content) {
+      const DOMPurify = createDOMPurify(window as unknown as Window);
+      const clean = DOMPurify.sanitize(article.content);
+      self.postMessage({ html: clean });
+    } else {
+      self.postMessage({ html: null });
+    }
+  } catch (err) {
+    self.postMessage({ html: null, error: (err as Error).message });
+  }
+};
+
+export {};


### PR DESCRIPTION
## Summary
- add web worker to fetch article HTML, run Readability and sanitize output
- expose `fetchReadableHtml` query to retrieve cleaned article content

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0a0ed7ce48332bf079d6dbb1f5d56