### PR TITLE
Select largest content image with og:image fallback

### DIFF
--- a/src/lib/fetcher.test.ts
+++ b/src/lib/fetcher.test.ts
@@ -1,0 +1,24 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect } from 'vitest';
+import { extractMainImage } from './fetcher.ts';
+
+const base = 'https://example.com/page';
+
+describe('extractMainImage', () => {
+  it('chooses the largest image in the content', () => {
+    const html = `
+      <html><body>
+        <img src="small.jpg" width="100" height="100" />
+        <img src="large.jpg" width="600" height="400" />
+      </body></html>`;
+    expect(extractMainImage(html, base)).toBe('https://example.com/large.jpg');
+  });
+
+  it('falls back to og:image when no imgs found', () => {
+    const html = `
+      <html><head>
+        <meta property="og:image" content="/meta.jpg" />
+      </head><body>No images</body></html>`;
+    expect(extractMainImage(html, base)).toBe('https://example.com/meta.jpg');
+  });
+});


### PR DESCRIPTION
## Summary
- extract main image by choosing largest `<img>` in content
- fall back to `<meta property="og:image">` when no images found
- add tests covering image selection and fallback

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0a677161c83328ac82a8cb3c5c8cd