### PR TITLE
feat: add domain-specific comic rules

### DIFF
--- a/src/lib/domainRules.json
+++ b/src/lib/domainRules.json
@@ -1,0 +1,4 @@
+{
+  "xkcd.com": { "image": "#comic img" },
+  "www.smbc-comics.com": { "image": "#cc-comic" }
+}

--- a/src/lib/fetcher.test.ts
+++ b/src/lib/fetcher.test.ts
@@ -21,4 +21,15 @@ describe('extractMainImage', () => {
       </head><body>No images</body></html>`;
     expect(extractMainImage(html, base)).toBe('https://example.com/meta.jpg');
   });
+
+  it('uses domain-specific selectors before heuristics', () => {
+    const html = `
+      <html><body>
+        <img src="large.jpg" width="800" height="600" />
+        <div id="comic"><img src="/comic.png" /></div>
+      </body></html>`;
+    expect(extractMainImage(html, 'https://xkcd.com/1/')).toBe(
+      'https://xkcd.com/comic.png',
+    );
+  });
 });

--- a/src/lib/fetcher.ts
+++ b/src/lib/fetcher.ts
@@ -1,3 +1,5 @@
+import domainRulesData from './domainRules.json' assert { type: 'json' };
+
 export interface FetchFeedOptions {
   etag?: string | null;
   lastModified?: string | null;
@@ -74,6 +76,21 @@ export async function fetchFeed(
  */
 export function extractMainImage(html: string, baseUrl: string): string | null {
   const doc = new DOMParser().parseFromString(html, 'text/html');
+
+  const hostname = new URL(baseUrl).hostname;
+  const domainRules = domainRulesData as Record<string, { image: string }>;
+  const rule = domainRules[hostname];
+  if (rule?.image) {
+    const img = doc.querySelector<HTMLImageElement>(rule.image);
+    const src = img?.getAttribute('src') || img?.getAttribute('data-src');
+    if (src) {
+      try {
+        return new URL(src, baseUrl).href;
+      } catch {
+        return src;
+      }
+    }
+  }
 
   let bestSrc: string | null = null;
   let bestArea = 0;

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -10,6 +10,7 @@
     /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
     "verbatimModuleSyntax": true,
     "moduleDetection": "force",
     "noEmit": true,


### PR DESCRIPTION
## Summary
- add JSON map of per-domain selectors for popular webcomics like xkcd and SMBC
- apply domain rules before generic heuristics when extracting main images
- enable JSON imports in the TS config and cover new behavior with tests

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a0a7ec06608332b64ca52179f4f89a