### PR TITLE
Animate feed list and article transitions

### DIFF
--- a/src/features/feeds/FeedListPage.tsx
+++ b/src/features/feeds/FeedListPage.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
+import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
 import { Button, ListItem, Panel } from '../../components';
 import { db } from '../../lib/db';
 import type { Feed } from '../../lib/db';
@@ -108,6 +109,13 @@ export function FeedListPage() {
     URL.revokeObjectURL(url);
   };
 
+  const MotionListItem = motion(ListItem);
+  const reduceMotion = useReducedMotion();
+  const itemVariants = {
+    hidden: { opacity: 0, y: -8 },
+    visible: { opacity: 1, y: 0 },
+  };
+
   return (
     <Panel>
       <h1>Feeds</h1>
@@ -117,18 +125,27 @@ export function FeedListPage() {
             <h2>{folderList.find((f) => f.id === folderId)?.name}</h2>
           )}
           <ul>
-            {fs.map((f) => (
-              <ListItem key={f.id}>
-                {f.latestArticleId ? (
-                  <Link to={`/reader/${f.latestArticleId}`}>{f.title}</Link>
-                ) : (
-                  f.title
-                )}{' '}
-                <span>({f.unread})</span>
-                <Button onClick={() => handleEdit(f)}>Edit</Button>
-                <Button onClick={() => handleDelete(f)}>Delete</Button>
-              </ListItem>
-            ))}
+            <AnimatePresence initial={false}>
+              {fs.map((f) => (
+                <MotionListItem
+                  key={f.id}
+                  variants={itemVariants}
+                  initial="hidden"
+                  animate="visible"
+                  exit="hidden"
+                  transition={{ duration: reduceMotion ? 0 : 0.15 }}
+                >
+                  {f.latestArticleId ? (
+                    <Link to={`/reader/${f.latestArticleId}`}>{f.title}</Link>
+                  ) : (
+                    f.title
+                  )}{' '}
+                  <span>({f.unread})</span>
+                  <Button onClick={() => handleEdit(f)}>Edit</Button>
+                  <Button onClick={() => handleDelete(f)}>Delete</Button>
+                </MotionListItem>
+              ))}
+            </AnimatePresence>
           </ul>
         </div>
       ))}

--- a/src/features/reader/ReaderPage.tsx
+++ b/src/features/reader/ReaderPage.tsx
@@ -1,5 +1,6 @@
 import { useState, type SyntheticEvent } from 'react';
 import { useParams } from 'react-router-dom';
+import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
 import { Button, Panel } from '../../components';
 import { db } from '../../lib/db';
 import { sanitize } from '../../lib/sanitize';
@@ -21,6 +22,8 @@ export function ReaderPage() {
 
   const panZoom = usePanZoom();
   const [caption, setCaption] = useState('');
+  const [expanded, setExpanded] = useState(true);
+  const reduceMotion = useReducedMotion();
 
   if (!data?.article || !data.feed) {
     return <Panel>Article not found</Panel>;
@@ -82,12 +85,26 @@ export function ReaderPage() {
           {caption && <figcaption className="caption">{caption}</figcaption>}
         </figure>
       )}
-      {sanitizedHtml && (
-        <div
-          className="reader-content"
-          dangerouslySetInnerHTML={{ __html: sanitizedHtml }}
-        />
-      )}
+      <AnimatePresence initial={false}>
+        {expanded && sanitizedHtml && (
+          <motion.div
+            key="article-content"
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: reduceMotion ? 0 : 0.2 }}
+            style={{ overflow: 'hidden' }}
+          >
+            <div
+              className="reader-content"
+              dangerouslySetInnerHTML={{ __html: sanitizedHtml }}
+            />
+          </motion.div>
+        )}
+      </AnimatePresence>
+      <Button onClick={() => setExpanded((e) => !e)}>
+        {expanded ? 'Collapse' : 'Expand'} Article
+      </Button>
       <Button onClick={handleOpenOriginal}>Open Original</Button>
       <Button onClick={handleMarkUnread}>Mark Unread</Button>
     </Panel>


### PR DESCRIPTION
## Summary
- animate feed list items with motion components and enter/exit variants
- add expandable article content with framer-motion transitions

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0a95a82a883329b2c681ee12c77cc