### PR TITLE
Respect reduced motion preference in animations

### DIFF
--- a/src/features/feeds/FeedListPage.tsx
+++ b/src/features/feeds/FeedListPage.tsx
@@ -111,10 +111,9 @@ export function FeedListPage() {
 
   const MotionListItem = motion(ListItem);
   const reduceMotion = useReducedMotion();
-  const itemVariants = {
-    hidden: { opacity: 0, y: -8 },
-    visible: { opacity: 1, y: 0 },
-  };
+  const itemVariants = reduceMotion
+    ? { hidden: { opacity: 0 }, visible: { opacity: 1 } }
+    : { hidden: { opacity: 0, y: -8 }, visible: { opacity: 1, y: 0 } };
 
   return (
     <Panel>
@@ -125,14 +124,14 @@ export function FeedListPage() {
             <h2>{folderList.find((f) => f.id === folderId)?.name}</h2>
           )}
           <ul>
-            <AnimatePresence initial={false}>
+            <AnimatePresence initial={!reduceMotion}>
               {fs.map((f) => (
                 <MotionListItem
                   key={f.id}
                   variants={itemVariants}
-                  initial="hidden"
+                  initial={reduceMotion ? false : 'hidden'}
                   animate="visible"
-                  exit="hidden"
+                  exit={reduceMotion ? undefined : 'hidden'}
                   transition={{ duration: reduceMotion ? 0 : 0.15 }}
                 >
                   {f.latestArticleId ? (

--- a/src/features/reader/ReaderPage.css
+++ b/src/features/reader/ReaderPage.css
@@ -15,3 +15,9 @@
   cursor: grab;
   transition: transform 0.2s ease-out;
 }
+
+@media (prefers-reduced-motion: reduce) {
+  .reader-image-container img {
+    transition: none;
+  }
+}

--- a/src/features/reader/ReaderPage.tsx
+++ b/src/features/reader/ReaderPage.tsx
@@ -85,13 +85,13 @@ export function ReaderPage() {
           {caption && <figcaption className="caption">{caption}</figcaption>}
         </figure>
       )}
-      <AnimatePresence initial={false}>
+      <AnimatePresence initial={!reduceMotion}>
         {expanded && sanitizedHtml && (
           <motion.div
             key="article-content"
-            initial={{ height: 0, opacity: 0 }}
+            initial={reduceMotion ? false : { height: 0, opacity: 0 }}
             animate={{ height: 'auto', opacity: 1 }}
-            exit={{ height: 0, opacity: 0 }}
+            exit={reduceMotion ? undefined : { height: 0, opacity: 0 }}
             transition={{ duration: reduceMotion ? 0 : 0.2 }}
             style={{ overflow: 'hidden' }}
           >


### PR DESCRIPTION
## Summary
- Conditionally disable reader expand/collapse motion and feed list item transitions when `prefers-reduced-motion` is enabled
- Stop image pan/zoom transition when reduced motion is requested

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0ae91c0f88332af3702be8c87dcde