### PR TITLE
fix: align component types for build

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -9,7 +9,7 @@ import {
 import { Button } from '../components';
 import { FeedListPage } from '../features/feeds/FeedListPage';
 import { ReaderPage } from '../features/reader/ReaderPage';
-import { useTheme } from '../theme/theme';
+import { useTheme, type Theme } from '../theme/theme';
 
 function App() {
   const { theme, setTheme } = useTheme();
@@ -25,8 +25,8 @@ function Layout({
   theme,
   setTheme,
 }: {
-  theme: string;
-  setTheme: (t: string) => void;
+  theme: Theme;
+  setTheme: (t: Theme) => void;
 }) {
   const location = useLocation();
   const mainRef = useRef<HTMLElement>(null);

--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -1,8 +1,12 @@
-import { useEffect, useRef, type ButtonHTMLAttributes } from 'react';
-import { motion, useAnimationControls } from 'framer-motion';
+import { useEffect, useRef } from 'react';
+import {
+  motion,
+  useAnimationControls,
+  type HTMLMotionProps,
+} from 'framer-motion';
 import './IconButton.css';
 
-interface IconButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+interface IconButtonProps extends Omit<HTMLMotionProps<'button'>, 'ref'> {
   pulse?: number;
 }
 


### PR DESCRIPTION
## Summary
- align App layout theme types with Theme
- use Framer Motion's button props to avoid drag handler conflicts

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0b92e42208332a13c137cce9982bd