### PR TITLE
feat: announce article read state changes

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import {
   BrowserRouter,
   Routes,
@@ -10,6 +10,7 @@ import { Button } from '../components';
 import { FeedListPage } from '../features/feeds/FeedListPage';
 import { ReaderPage } from '../features/reader/ReaderPage';
 import { useTheme, type Theme } from '../theme/theme';
+import { LiveRegionContext } from '../hooks/useLiveRegion.ts';
 
 function App() {
   const { theme, setTheme } = useTheme();
@@ -30,6 +31,7 @@ function Layout({
 }) {
   const location = useLocation();
   const mainRef = useRef<HTMLElement>(null);
+  const [liveMessage, setLiveMessage] = useState('');
 
   useEffect(() => {
     mainRef.current?.focus();
@@ -41,10 +43,13 @@ function Layout({
   };
 
   return (
-    <>
+    <LiveRegionContext.Provider value={setLiveMessage}>
       <a href="#main-content" className="skip-link" onClick={handleSkip}>
         Skip to main content
       </a>
+      <div aria-live="polite" className="sr-only">
+        {liveMessage}
+      </div>
       <header aria-label="Site header">
         <nav aria-label="Primary navigation">
           <Link to="/">Feeds</Link>
@@ -67,7 +72,7 @@ function Layout({
       <footer aria-label="Site footer">
         <p>RSS Web Comics Reader</p>
       </footer>
-    </>
+    </LiveRegionContext.Provider>
   );
 }
 

--- a/src/features/reader/ReaderPage.tsx
+++ b/src/features/reader/ReaderPage.tsx
@@ -8,6 +8,7 @@ import { registerShortcuts } from '../../lib/shortcuts.ts';
 import { sanitize } from '../../lib/sanitize';
 import { useDexieLiveQuery } from '../../hooks/useDexieLiveQuery';
 import { usePanZoom } from '../../hooks/usePanZoom';
+import { useLiveRegion } from '../../hooks/useLiveRegion.ts';
 import './ReaderPage.css';
 import '../../styles/caption.css';
 
@@ -27,6 +28,7 @@ export function ReaderPage() {
   const [caption, setCaption] = useState('');
   const [expanded, setExpanded] = useState(true);
   const reduceMotion = useReducedMotion();
+  const announce = useLiveRegion();
 
   const handleOpenOriginal = () => {
     if (!data?.article) return;
@@ -39,8 +41,10 @@ export function ReaderPage() {
     const isRead = await readStateRepo.isRead(article.id!);
     if (isRead) {
       await readStateRepo.markUnread(article.id!);
+      announce('Marked as unread');
     } else {
       await readStateRepo.markRead(article.id!);
+      announce('Marked as read');
     }
   };
 

--- a/src/hooks/useLiveRegion.ts
+++ b/src/hooks/useLiveRegion.ts
@@ -1,0 +1,9 @@
+import { createContext, useContext } from 'react';
+
+export const LiveRegionContext = createContext<(message: string) => void>(
+  () => {},
+);
+
+export function useLiveRegion() {
+  return useContext(LiveRegionContext);
+}

--- a/src/index.css
+++ b/src/index.css
@@ -56,3 +56,15 @@ button:disabled {
 .skip-link:focus {
   top: 0;
 }
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}


### PR DESCRIPTION
## Summary
- add a visually-hidden aria-live region to the layout for screen reader updates
- expose a `useLiveRegion` hook and announce read/unread status changes
- style new `sr-only` helper class

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0c71d4328833295ca0e518c410a15