### PR TITLE
feat: add Workbox runtime caching for articles and images

### DIFF
--- a/src/sw.ts
+++ b/src/sw.ts
@@ -2,6 +2,9 @@
 
 import { clientsClaim } from 'workbox-core';
 import { precacheAndRoute } from 'workbox-precaching';
+import { registerRoute } from 'workbox-routing';
+import { NetworkFirst, CacheFirst } from 'workbox-strategies';
+import { ExpirationPlugin } from 'workbox-expiration';
 
 declare let self: ServiceWorkerGlobalScope & {
   __WB_MANIFEST: Array<import('workbox-build').ManifestEntry>;
@@ -11,3 +14,30 @@ self.skipWaiting();
 clientsClaim();
 
 precacheAndRoute(self.__WB_MANIFEST);
+
+const MAX_ARTICLES = 50;
+const MAX_IMAGES = 100;
+
+registerRoute(
+  ({ request, url }) => request.mode === 'navigate' && url.pathname === '/',
+  new NetworkFirst({
+    cacheName: 'app-shell',
+  }),
+);
+
+registerRoute(
+  ({ request, url }) =>
+    request.mode === 'navigate' && url.pathname.startsWith('/reader/'),
+  new NetworkFirst({
+    cacheName: 'articles',
+    plugins: [new ExpirationPlugin({ maxEntries: MAX_ARTICLES })],
+  }),
+);
+
+registerRoute(
+  ({ request }) => request.destination === 'image',
+  new CacheFirst({
+    cacheName: 'images',
+    plugins: [new ExpirationPlugin({ maxEntries: MAX_IMAGES })],
+  }),
+);

--- a/tasks/011.offline-and-caching.md
+++ b/tasks/011.offline-and-caching.md
@@ -3,14 +3,17 @@
 **Goal:** Read previously fetched content offline.
 
 ## Deliverables
+
 - Service Worker with Workbox: cache app shell, last N article pages, last N images per feed.
 - Background sync (when online) to resume failed fetches (best-effort; optional).
 
 ## Acceptance Criteria
+
 - After initial sync, user can open the app offline and read previously opened articles/images.
 - Storage budgets respected; LRU eviction policy for cached images.
 
 ## Checklist
-- [ ] SW + Workbox
-- [ ] Shell + articles cache
-- [ ] LRU for images
+
+- [x] SW + Workbox
+- [x] Shell + articles cache
+- [x] LRU for images


### PR DESCRIPTION
## Summary
- cache app shell and articles with Workbox runtime routes
- use LRU cache for images to drop oldest entries
- mark offline & caching task checklist complete

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0d0dc13d88332882b8ff478bf67f6