### PR TITLE
feat: queue offline requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "vite": "^7.1.2",
         "vite-plugin-pwa": "^1.0.2",
         "vitest": "^3.2.4",
+        "workbox-background-sync": "^7.3.0",
         "workbox-build": "^7.3.0",
         "workbox-window": "^7.3.0"
       },

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "vite": "^7.1.2",
     "vite-plugin-pwa": "^1.0.2",
     "vitest": "^3.2.4",
+    "workbox-background-sync": "^7.3.0",
     "workbox-build": "^7.3.0",
     "workbox-window": "^7.3.0"
   },

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -5,6 +5,7 @@ import { precacheAndRoute } from 'workbox-precaching';
 import { registerRoute } from 'workbox-routing';
 import { NetworkFirst, CacheFirst } from 'workbox-strategies';
 import { ExpirationPlugin } from 'workbox-expiration';
+import { BackgroundSyncPlugin } from 'workbox-background-sync';
 
 declare let self: ServiceWorkerGlobalScope & {
   __WB_MANIFEST: Array<import('workbox-build').ManifestEntry>;
@@ -18,6 +19,23 @@ precacheAndRoute(self.__WB_MANIFEST);
 const MAX_ARTICLES = 50;
 const MAX_IMAGES = 100;
 
+const articleQueue = new BackgroundSyncPlugin('article-queue', {
+  maxRetentionTime: 24 * 60,
+  onSync: async ({ queue }) => {
+    let entry;
+    while ((entry = await queue.shiftRequest())) {
+      try {
+        const response = await fetch(entry.request);
+        const cache = await caches.open('articles');
+        await cache.put(entry.request, response.clone());
+      } catch (error) {
+        await queue.unshiftRequest(entry);
+        throw error;
+      }
+    }
+  },
+});
+
 registerRoute(
   ({ request, url }) => request.mode === 'navigate' && url.pathname === '/',
   new NetworkFirst({
@@ -30,7 +48,7 @@ registerRoute(
     request.mode === 'navigate' && url.pathname.startsWith('/reader/'),
   new NetworkFirst({
     cacheName: 'articles',
-    plugins: [new ExpirationPlugin({ maxEntries: MAX_ARTICLES })],
+    plugins: [articleQueue, new ExpirationPlugin({ maxEntries: MAX_ARTICLES })],
   }),
 );
 


### PR DESCRIPTION
## Summary
- add workbox Background Sync plugin to service worker
- queue article requests and cache them when back online

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0d2ec60c083329d863e6d0591a5ba