### PR TITLE
Add preferences table and reactive settings context

### DIFF
--- a/src/features/settings/SettingsContext.tsx
+++ b/src/features/settings/SettingsContext.tsx
@@ -1,0 +1,59 @@
+/* eslint react-refresh/only-export-components: off */
+import { createContext, useContext, type ReactNode } from 'react';
+import { usePreference } from '../../hooks/usePreference.ts';
+
+interface SettingsContextValue {
+  autoMarkReadThreshold: string;
+  setAutoMarkReadThreshold: (v: string) => Promise<unknown>;
+  syncEveryMinutes: string;
+  setSyncEveryMinutes: (v: string) => Promise<unknown>;
+  proxyUrl: string;
+  setProxyUrl: (v: string) => Promise<unknown>;
+  imageZoom: string;
+  setImageZoom: (v: string) => Promise<unknown>;
+}
+
+const SettingsContext = createContext<SettingsContextValue>({
+  autoMarkReadThreshold: '60',
+  setAutoMarkReadThreshold: async () => {},
+  syncEveryMinutes: '30',
+  setSyncEveryMinutes: async () => {},
+  proxyUrl: '',
+  setProxyUrl: async () => {},
+  imageZoom: '1',
+  setImageZoom: async () => {},
+});
+
+export function SettingsProvider({ children }: { children: ReactNode }) {
+  const [autoMarkReadThreshold, setAutoMarkReadThreshold] = usePreference(
+    'autoMarkReadThreshold',
+    '60',
+  );
+  const [syncEveryMinutes, setSyncEveryMinutes] = usePreference(
+    'syncEveryMinutes',
+    '30',
+  );
+  const [proxyUrl, setProxyUrl] = usePreference('proxyUrl', '');
+  const [imageZoom, setImageZoom] = usePreference('imageZoom', '1');
+
+  return (
+    <SettingsContext.Provider
+      value={{
+        autoMarkReadThreshold,
+        setAutoMarkReadThreshold,
+        syncEveryMinutes,
+        setSyncEveryMinutes,
+        proxyUrl,
+        setProxyUrl,
+        imageZoom,
+        setImageZoom,
+      }}
+    >
+      {children}
+    </SettingsContext.Provider>
+  );
+}
+
+export function useSettings() {
+  return useContext(SettingsContext);
+}

--- a/src/features/settings/SettingsPage.tsx
+++ b/src/features/settings/SettingsPage.tsx
@@ -1,57 +1,22 @@
-import { useEffect, useState } from 'react';
 import { Panel } from '../../components';
-import { settingsRepo } from '../../lib/repositories';
 import { useTheme, type Theme } from '../../theme/theme';
+import { useSettings } from './SettingsContext.tsx';
 
 export function SettingsPage() {
   const { theme, setTheme } = useTheme();
-  const [autoThreshold, setAutoThreshold] = useState('60');
-  const [syncMinutes, setSyncMinutes] = useState('30');
-  const [proxyUrl, setProxyUrl] = useState('');
-  const [imageZoom, setImageZoom] = useState('1');
-
-  useEffect(() => {
-    const load = async () => {
-      const [t, s, p, z] = await Promise.all([
-        settingsRepo.get('autoMarkReadThreshold'),
-        settingsRepo.get('syncEveryMinutes'),
-        settingsRepo.get('proxyUrl'),
-        settingsRepo.get('imageZoom'),
-      ]);
-      if (t) setAutoThreshold(t.value);
-      if (s) setSyncMinutes(s.value);
-      if (p) setProxyUrl(p.value);
-      if (z) setImageZoom(z.value);
-    };
-    load();
-  }, []);
+  const {
+    autoMarkReadThreshold: autoThreshold,
+    setAutoMarkReadThreshold: setAutoThreshold,
+    syncEveryMinutes: syncMinutes,
+    setSyncEveryMinutes: setSyncMinutes,
+    proxyUrl,
+    setProxyUrl,
+    imageZoom,
+    setImageZoom,
+  } = useSettings();
 
   const handleThemeChange = (value: Theme) => {
     setTheme(value);
-  };
-
-  const handleThresholdChange = async (value: string) => {
-    setAutoThreshold(value);
-    await settingsRepo.set('autoMarkReadThreshold', value);
-  };
-
-  const handleSyncChange = async (value: string) => {
-    setSyncMinutes(value);
-    await settingsRepo.set('syncEveryMinutes', value);
-  };
-
-  const handleProxyChange = async (value: string) => {
-    setProxyUrl(value);
-    if (value) {
-      await settingsRepo.set('proxyUrl', value);
-    } else {
-      await settingsRepo.remove('proxyUrl');
-    }
-  };
-
-  const handleImageZoomChange = async (value: string) => {
-    setImageZoom(value);
-    await settingsRepo.set('imageZoom', value);
   };
 
   return (
@@ -75,7 +40,7 @@ export function SettingsPage() {
           <input
             type="number"
             value={autoThreshold}
-            onChange={(e) => handleThresholdChange(e.target.value)}
+            onChange={(e) => setAutoThreshold(e.target.value)}
           />
         </label>
       </div>
@@ -85,7 +50,7 @@ export function SettingsPage() {
           <input
             type="number"
             value={syncMinutes}
-            onChange={(e) => handleSyncChange(e.target.value)}
+            onChange={(e) => setSyncMinutes(e.target.value)}
           />
         </label>
       </div>
@@ -95,7 +60,7 @@ export function SettingsPage() {
           <input
             type="url"
             value={proxyUrl}
-            onChange={(e) => handleProxyChange(e.target.value)}
+            onChange={(e) => setProxyUrl(e.target.value)}
           />
         </label>
       </div>
@@ -106,7 +71,7 @@ export function SettingsPage() {
             type="number"
             step="0.1"
             value={imageZoom}
-            onChange={(e) => handleImageZoomChange(e.target.value)}
+            onChange={(e) => setImageZoom(e.target.value)}
           />
         </label>
       </div>

--- a/src/hooks/usePreference.ts
+++ b/src/hooks/usePreference.ts
@@ -1,0 +1,22 @@
+import { useCallback } from 'react';
+import { db } from '../lib/db';
+import { useDexieLiveQuery } from './useDexieLiveQuery.ts';
+
+export function usePreference(key: string, defaultValue: string) {
+  const value = useDexieLiveQuery(async () => {
+    const pref = await db.preferences.get(key);
+    return pref?.value ?? defaultValue;
+  }, [key, defaultValue]);
+
+  const set = useCallback(
+    (val: string) => {
+      if (val) {
+        return db.preferences.put({ key, value: val });
+      }
+      return db.preferences.delete(key);
+    },
+    [key],
+  );
+
+  return [value ?? defaultValue, set] as const;
+}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -31,6 +31,11 @@ export interface Setting {
   value: string;
 }
 
+export interface Preference {
+  key: string;
+  value: string;
+}
+
 export interface Folder {
   id?: number;
   name: string;
@@ -49,6 +54,7 @@ class AppDB extends Dexie {
   articles!: Table<Article, number>;
   readState!: Table<ReadState, number>;
   settings!: Table<Setting, string>;
+  preferences!: Table<Preference, string>;
   folders!: Table<Folder, number>;
   syncLog!: Table<SyncLog, number>;
 
@@ -64,6 +70,15 @@ class AppDB extends Dexie {
       readState: 'articleId',
       folders: '++id, name',
       syncLog: '++id, feedId, runAt',
+    });
+    this.version(3).stores({
+      settings: '&key',
+      feeds: '++id, url, folderId',
+      articles: '++id, feedId, publishedAt',
+      readState: 'articleId',
+      folders: '++id, name',
+      syncLog: '++id, feedId, runAt',
+      preferences: '&key',
     });
   }
 }

--- a/src/lib/repositories/settings.ts
+++ b/src/lib/repositories/settings.ts
@@ -1,13 +1,16 @@
-import { db, type Setting } from '../db.ts';
+import { db, type Preference } from '../db.ts';
 
 export const settingsRepo = {
   async set(key: string, value: string) {
-    return db.settings.put({ key, value } satisfies Setting);
+    if (value) {
+      return db.preferences.put({ key, value } satisfies Preference);
+    }
+    return db.preferences.delete(key);
   },
   async get(key: string) {
-    return db.settings.get(key);
+    return db.preferences.get(key);
   },
   async remove(key: string) {
-    return db.settings.delete(key);
+    return db.preferences.delete(key);
   },
 };

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,11 +3,14 @@ import { createRoot } from 'react-dom/client';
 import './index.css';
 import App from './app/App.tsx';
 import { ThemeProvider } from './theme/ThemeProvider.tsx';
+import { SettingsProvider } from './features/settings/SettingsContext.tsx';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <ThemeProvider>
-      <App />
+      <SettingsProvider>
+        <App />
+      </SettingsProvider>
     </ThemeProvider>
   </StrictMode>,
 );

--- a/src/theme/ThemeProvider.tsx
+++ b/src/theme/ThemeProvider.tsx
@@ -15,7 +15,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
       }
     };
     const load = async () => {
-      const stored = await db.settings.get('theme');
+      const stored = await db.preferences.get('theme');
       if (stored) {
         userPref.current = true;
         setThemeState(stored.value as Theme);
@@ -31,7 +31,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     document.documentElement.setAttribute('data-theme', theme);
     if (userPref.current) {
-      db.settings.put({ key: 'theme', value: theme });
+      db.preferences.put({ key: 'theme', value: theme });
     }
   }, [theme]);
 


### PR DESCRIPTION
## Summary
- add `preferences` table to Dexie with schema migration
- store settings with a reactive context that syncs to Dexie
- persist theme and other options via new settings provider

## Testing
- `npm test -- --run`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a0d6818ed083329813a0233c851a41