### PR TITLE
feat: add article search and filters

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -14,6 +14,7 @@ export interface Article {
   id?: number;
   feedId: number;
   title: string;
+  titleLower: string;
   link: string;
   publishedAt: Date;
   mainImageUrl?: string | null;
@@ -80,6 +81,24 @@ class AppDB extends Dexie {
       syncLog: '++id, feedId, runAt',
       preferences: '&key',
     });
+    this.version(4)
+      .stores({
+        settings: '&key',
+        feeds: '++id, url, folderId',
+        articles: '++id, feedId, publishedAt, titleLower',
+        readState: 'articleId',
+        folders: '++id, name',
+        syncLog: '++id, feedId, runAt',
+        preferences: '&key',
+      })
+      .upgrade(async (tx) => {
+        await tx
+          .table('articles')
+          .toCollection()
+          .modify((a: Article) => {
+            a.titleLower = a.title.toLowerCase();
+          });
+      });
   }
 }
 

--- a/src/lib/queries.test.ts
+++ b/src/lib/queries.test.ts
@@ -1,0 +1,68 @@
+import 'fake-indexeddb/auto';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { db } from './db.ts';
+import { feedsRepo } from './repositories/feeds.ts';
+import { articlesRepo } from './repositories/articles.ts';
+import { readStateRepo } from './repositories/readState.ts';
+import { searchArticles } from './queries.ts';
+
+beforeEach(async () => {
+  await db.delete();
+  await db.open();
+});
+
+describe('searchArticles', () => {
+  it('applies keyword, feed, folder, unread and image filters', async () => {
+    const folderId = await db.folders.add({ name: 'Faves' });
+    const feed1 = await feedsRepo.add({
+      url: 'https://a',
+      title: 'Feed A',
+      folderId,
+    });
+    const feed2 = await feedsRepo.add({
+      url: 'https://b',
+      title: 'Feed B',
+    });
+    const a1 = await articlesRepo.add({
+      feedId: feed1,
+      title: 'Hello World',
+      link: 'https://a/1',
+      publishedAt: new Date(),
+    });
+    const a2 = await articlesRepo.add({
+      feedId: feed1,
+      title: 'Image Post',
+      link: 'https://a/2',
+      publishedAt: new Date(),
+      mainImageUrl: 'img.png',
+    });
+    await articlesRepo.add({
+      feedId: feed2,
+      title: 'Another Hello',
+      link: 'https://b/1',
+      publishedAt: new Date(),
+    });
+    await readStateRepo.markRead(a2);
+
+    const kw = await searchArticles({ keyword: 'hello' });
+    expect(kw.map((a) => a.title).sort()).toEqual([
+      'Another Hello',
+      'Hello World',
+    ]);
+
+    const byFeed = await searchArticles({ feedId: feed1 });
+    expect(byFeed.map((a) => a.id).sort()).toEqual([a1, a2]);
+
+    const byFolder = await searchArticles({ folderId });
+    expect(byFolder.map((a) => a.id).sort()).toEqual([a1, a2]);
+
+    const unreadOnly = await searchArticles({
+      feedId: feed1,
+      unreadOnly: true,
+    });
+    expect(unreadOnly.map((a) => a.id)).toEqual([a1]);
+
+    const withImages = await searchArticles({ hasImage: true });
+    expect(withImages.map((a) => a.id)).toEqual([a2]);
+  });
+});

--- a/src/lib/repositories/articles.ts
+++ b/src/lib/repositories/articles.ts
@@ -1,8 +1,11 @@
 import { db, type Article } from '../db.ts';
 
 export const articlesRepo = {
-  async add(article: Omit<Article, 'id'>) {
-    return db.articles.add(article);
+  async add(article: Omit<Article, 'id' | 'titleLower'>) {
+    return db.articles.add({
+      ...article,
+      titleLower: article.title.toLowerCase(),
+    });
   },
   async get(id: number) {
     return db.articles.get(id);


### PR DESCRIPTION
## Summary
- index article titles in Dexie and expose search helper
- add feed list search bar with feed, folder, unread and image filters
- cover article search with unit tests

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a0ef2271f883328437464bb37a9572