### PR TITLE
Add QA docs and in-app help modal

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+# Contributing
+
+## Setup
+
+1. `npm install`
+2. `npm test`
+3. `npm run dev`
+
+## Guidelines
+
+- Check [AGENTS.md](./AGENTS.md) and the [tasks](./tasks) directory before starting work.
+- Use TypeScript and keep styles consistent with existing code.
+- Run `npm test` and `npm run lint` before committing.
+- Pull requests should target the `main` branch.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A Vite-powered React + TypeScript single-page app. The project is preconfigured with ESLint, Prettier, and strict TypeScript settings. Core libraries like Dexie for IndexedDB, Framer Motion for animations, and Mozilla Readability are included.
 
+See [AGENTS.md](./AGENTS.md) for high-level architecture and the [tasks](./tasks) directory for the project roadmap.
+
 ## Development
 
 ```bash

--- a/docs/qa-playbook.md
+++ b/docs/qa-playbook.md
@@ -1,0 +1,24 @@
+# QA Playbook
+
+## Scenarios
+
+- **First run**
+  - [ ] Load application in a fresh browser profile
+  - [ ] Verify default theme matches system preference
+- **Add feeds**
+  - [ ] Add a new feed URL
+  - [ ] Edit and delete feeds
+- **Import OPML**
+  - [ ] Import sample OPML file
+  - [ ] Confirm feeds appear
+- **Refresh**
+  - [ ] Trigger manual refresh and observe new articles
+- **Read flow**
+  - [ ] Open article and ensure images center with alt text
+  - [ ] Mark as read automatically when scrolled
+- **Offline**
+  - [ ] Enable offline mode and read previously fetched articles
+- **Theme toggle**
+  - [ ] Switch between light and dark modes
+- **Reduced motion**
+  - [ ] Enable reduced motion setting and verify animations disabled

--- a/docs/uat-scripts.md
+++ b/docs/uat-scripts.md
@@ -1,0 +1,9 @@
+# UAT Scripts
+
+- [ ] User can add, edit, and delete feeds
+- [ ] OPML import restores feeds
+- [ ] Articles refresh on demand
+- [ ] Reader marks articles as read after viewing
+- [ ] App functions offline for cached articles
+- [ ] Theme toggle persists selection
+- [ ] Reduced motion setting respected

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -7,6 +7,7 @@ import {
   useLocation,
 } from 'react-router-dom';
 import { Button } from '../components';
+import { HelpModal } from '../features/help/HelpModal.tsx';
 const FeedListPage = lazy(() =>
   import('../features/feeds/FeedListPage').then((m) => ({
     default: m.FeedListPage,
@@ -45,6 +46,7 @@ function Layout({
   const location = useLocation();
   const mainRef = useRef<HTMLElement>(null);
   const [liveMessage, setLiveMessage] = useState('');
+  const [showHelp, setShowHelp] = useState(false);
 
   useEffect(() => {
     mainRef.current?.focus();
@@ -67,9 +69,14 @@ function Layout({
         <nav aria-label="Primary navigation">
           <Link to="/">Feeds</Link> <Link to="/settings">Settings</Link>
         </nav>
-        <Button onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}>
-          Switch to {theme === 'light' ? 'dark' : 'light'} mode
-        </Button>
+        <div style={{ display: 'flex', gap: '0.5rem' }}>
+          <Button
+            onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
+          >
+            Switch to {theme === 'light' ? 'dark' : 'light'} mode
+          </Button>
+          <Button onClick={() => setShowHelp(true)}>Help</Button>
+        </div>
       </header>
       <main
         id="main-content"
@@ -88,6 +95,7 @@ function Layout({
       <footer aria-label="Site footer">
         <p>RSS Web Comics Reader</p>
       </footer>
+      {showHelp && <HelpModal onClose={() => setShowHelp(false)} />}
     </LiveRegionContext.Provider>
   );
 }

--- a/src/features/help/HelpModal.css
+++ b/src/features/help/HelpModal.css
@@ -1,0 +1,26 @@
+.help-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.help-modal {
+  background: var(--color-bg);
+  color: var(--color-text);
+  padding: var(--spacing-lg);
+  border-radius: var(--radius-md);
+  max-width: 32rem;
+  width: 90%;
+  max-height: 90vh;
+  overflow: auto;
+}
+
+.help-modal kbd {
+  background: var(--color-muted);
+  padding: 0 0.25rem;
+  border-radius: var(--radius-sm);
+}

--- a/src/features/help/HelpModal.tsx
+++ b/src/features/help/HelpModal.tsx
@@ -1,0 +1,51 @@
+import { Button } from '../../components';
+import './HelpModal.css';
+
+export function HelpModal({ onClose }: { onClose: () => void }) {
+  return (
+    <div
+      className="help-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="help-title"
+    >
+      <div className="help-modal">
+        <h2 id="help-title">Help</h2>
+        <section>
+          <h3>Keyboard shortcuts</h3>
+          <ul>
+            <li>
+              <kbd>j</kbd>/<kbd>k</kbd> — next/previous article
+            </li>
+            <li>
+              <kbd>u</kbd> — toggle unread
+            </li>
+            <li>
+              <kbd>o</kbd> — open original
+            </li>
+            <li>
+              <kbd>g</kbd> — go to feed list
+            </li>
+            <li>
+              <kbd>/</kbd> — search
+            </li>
+          </ul>
+        </section>
+        <section>
+          <h3>Import/Export</h3>
+          <p>Use Settings to import or export OPML and app settings.</p>
+        </section>
+        <section>
+          <h3>Proxy note</h3>
+          <p>
+            Some feeds require a CORS proxy. Configure one in Settings if
+            needed.
+          </p>
+        </section>
+        <Button onClick={onClose} style={{ marginTop: '1rem' }}>
+          Close
+        </Button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add QA playbook and UAT script docs
- document contributing workflow and link AGENTS/tasks from README
- add help modal with shortcuts and tips

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a17fa1abc4833285c5ac904eaabefe