### PR TITLE
fix: add Node type declarations for tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
       "devDependencies": {
         "@eslint/js": "^9.33.0",
         "@size-limit/file": "^8.2.6",
+        "@types/node": "^24.3.0",
         "@types/react": "^19.1.10",
         "@types/react-dom": "^19.1.7",
         "@vitejs/plugin-react": "^5.0.0",
@@ -3071,8 +3072,6 @@
       "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.10.0"
       }
@@ -8731,9 +8730,7 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
       "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",
+    "@size-limit/file": "^8.2.6",
+    "@types/node": "^24.3.0",
     "@types/react": "^19.1.10",
     "@types/react-dom": "^19.1.7",
     "@vitejs/plugin-react": "^5.0.0",
@@ -43,6 +45,7 @@
     "jsdom": "^26.1.0",
     "lint-staged": "^16.1.5",
     "prettier": "^3.3.3",
+    "size-limit": "^8.2.6",
     "typescript": "^5.9.2",
     "typescript-eslint": "^8.39.1",
     "vite": "^7.1.2",
@@ -50,9 +53,7 @@
     "vitest": "^3.2.4",
     "workbox-background-sync": "^7.3.0",
     "workbox-build": "^7.3.0",
-    "workbox-window": "^7.3.0",
-    "@size-limit/file": "^8.2.6",
-    "size-limit": "^8.2.6"
+    "workbox-window": "^7.3.0"
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx}": [


### PR DESCRIPTION
## Summary
- add Node type definitions so tests can import built-in modules

## Testing
- `npm run build`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a18ce90cf483328babfa01860cd117