### PR TITLE
feat(parser): handle rdf rss

### DIFF
--- a/src/lib/feedParser.test.ts
+++ b/src/lib/feedParser.test.ts
@@ -5,6 +5,8 @@ const rssSample = `<?xml version="1.0"?><rss version="2.0" xmlns:media="http://s
 
 const atomSample = `<?xml version="1.0"?><feed xmlns="http://www.w3.org/2005/Atom"><title>Sample Atom</title><entry><title>Entry 1</title><link href="http://example.com/a1"/><updated>2024-01-01T00:00:00Z</updated><media:content xmlns:media="http://search.yahoo.com/mrss/" url="http://example.com/a1.png" type="image/png"/></entry></feed>`;
 
+const rdfSample = `<?xml version="1.0"?><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/"><channel rdf:about="http://example.com"><title>Sample RDF</title></channel><item rdf:about="http://example.com/1"><title>Item 1</title><link>http://example.com/1</link><dc:date>2024-01-01T00:00:00Z</dc:date></item></rdf:RDF>`;
+
 describe('parseFeed', () => {
   it('parses RSS items', () => {
     const items = parseFeed(rssSample);
@@ -18,5 +20,11 @@ describe('parseFeed', () => {
     expect(items[0].title).toBe('Entry 1');
     expect(items[0].link).toBe('http://example.com/a1');
     expect(items[0].image).toBe('http://example.com/a1.png');
+  });
+
+  it('parses RSS 1.0 items', () => {
+    const items = parseFeed(rdfSample);
+    expect(items[0].title).toBe('Item 1');
+    expect(items[0].link).toBe('http://example.com/1');
   });
 });

--- a/src/lib/feedParser.ts
+++ b/src/lib/feedParser.ts
@@ -36,6 +36,28 @@ export function parseFeed(xml: string): ParsedItem[] {
     return items;
   }
 
+  if (json['rdf:RDF']) {
+    const rdf = json['rdf:RDF'];
+    const rdfItems = Array.isArray(rdf.item)
+      ? rdf.item
+      : rdf.item
+        ? [rdf.item]
+        : [];
+    for (const item of rdfItems) {
+      const image = item.enclosure?.type?.startsWith('image')
+        ? item.enclosure.url
+        : item['media:content']?.url;
+      const published = item.pubDate ?? item['dc:date'];
+      items.push({
+        title: item.title ?? '',
+        link: item.link ?? '',
+        publishedAt: published ? new Date(published) : new Date(),
+        image,
+      });
+    }
+    return items;
+  }
+
   if (json.feed) {
     const entries = Array.isArray(json.feed.entry)
       ? json.feed.entry


### PR DESCRIPTION
## Summary
- support RSS 1.0 feeds (`rdf:RDF`) in feed parser
- test RSS 1.0 parsing

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a197d582808332a531d54965f0ed2e