### PR TITLE
chore: use Node 22 in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
       - run: npm ci
       - run: npm run lint

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
       - run: npm ci
       - run: npm run build


### PR DESCRIPTION
## Summary
- use Node.js 22 for build and deploy workflows

## Testing
- `npm test`
- `npm run lint`
- `npm run build`
- `npm run size`


------
https://chatgpt.com/codex/tasks/task_e_68a19c7d907c8332916eecf1ed0f3dcf