### PR TITLE
Fix service worker path and add default CORS proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ npm run dev
 - `npm run format` – format with Prettier
 - `npm run size` – check bundle size against budget
 
+### CORS proxy
+
+Feeds that block cross-origin requests are fetched through a default proxy
+(`https://cors.isomorphic-git.org/`). You can override this URL in Settings.
+
 ## Folder Structure
 
 ```

--- a/src/features/feeds/AddFeedForm.tsx
+++ b/src/features/feeds/AddFeedForm.tsx
@@ -2,16 +2,18 @@ import { useState } from 'react';
 import { Button } from '../../components';
 import { db } from '../../lib/db';
 import { discoverFeed } from '../../lib/discoverFeed';
+import { useSettings } from '../settings/SettingsContext.tsx';
 
 export function AddFeedForm() {
   const [url, setUrl] = useState('');
   const [title, setTitle] = useState('');
   const [folder, setFolder] = useState('');
+  const { proxyUrl } = useSettings();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!url) return;
-    const feedUrl = await discoverFeed(url);
+    const feedUrl = await discoverFeed(url, proxyUrl);
     let folderId: number | null = null;
     if (folder) {
       const existing = await db.folders.where('name').equals(folder).first();

--- a/src/features/settings/SettingsContext.tsx
+++ b/src/features/settings/SettingsContext.tsx
@@ -1,6 +1,7 @@
 /* eslint react-refresh/only-export-components: off */
 import { createContext, useContext, type ReactNode } from 'react';
 import { usePreference } from '../../hooks/usePreference.ts';
+import { DEFAULT_PROXY } from '../../lib/fetcher.ts';
 
 interface SettingsContextValue {
   autoMarkReadThreshold: string;
@@ -18,7 +19,7 @@ const SettingsContext = createContext<SettingsContextValue>({
   setAutoMarkReadThreshold: async () => {},
   syncEveryMinutes: '30',
   setSyncEveryMinutes: async () => {},
-  proxyUrl: '',
+  proxyUrl: DEFAULT_PROXY,
   setProxyUrl: async () => {},
   imageZoom: '1',
   setImageZoom: async () => {},
@@ -33,7 +34,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     'syncEveryMinutes',
     '30',
   );
-  const [proxyUrl, setProxyUrl] = usePreference('proxyUrl', '');
+  const [proxyUrl, setProxyUrl] = usePreference('proxyUrl', DEFAULT_PROXY);
   const [imageZoom, setImageZoom] = usePreference('imageZoom', '1');
 
   return (

--- a/src/lib/discoverFeed.ts
+++ b/src/lib/discoverFeed.ts
@@ -1,6 +1,10 @@
 import { normalizeUrl } from './normalizeUrl';
+import { buildProxyUrl } from './fetcher.ts';
 
-export async function discoverFeed(url: string): Promise<string> {
+export async function discoverFeed(
+  url: string,
+  proxy?: string,
+): Promise<string> {
   try {
     if (url.endsWith('.xml') || url.endsWith('.rss') || url.endsWith('.atom')) {
       return normalizeUrl(url);
@@ -17,7 +21,23 @@ export async function discoverFeed(url: string): Promise<string> {
       return normalizeUrl(resolved);
     }
   } catch {
-    // ignore
+    if (proxy) {
+      try {
+        const res = await fetch(buildProxyUrl(proxy, url));
+        const text = await res.text();
+        const doc = new DOMParser().parseFromString(text, 'text/html');
+        const link = doc.querySelector(
+          'link[rel="alternate"][type="application/rss+xml"], link[rel="alternate"][type="application/atom+xml"]',
+        );
+        const href = link?.getAttribute('href');
+        if (href) {
+          const resolved = new URL(href, url).toString();
+          return normalizeUrl(resolved);
+        }
+      } catch {
+        // ignore
+      }
+    }
   }
   return normalizeUrl(url);
 }

--- a/src/lib/fetcher.ts
+++ b/src/lib/fetcher.ts
@@ -1,5 +1,13 @@
 import domainRulesData from './domainRules.json' assert { type: 'json' };
 
+export const DEFAULT_PROXY = 'https://cors.isomorphic-git.org';
+
+export function buildProxyUrl(proxy: string, url: string) {
+  return proxy.includes('?')
+    ? `${proxy}${encodeURIComponent(url)}`
+    : `${proxy}${url}`;
+}
+
 export interface FetchFeedOptions {
   etag?: string | null;
   lastModified?: string | null;
@@ -19,7 +27,12 @@ function delay(ms: number) {
  */
 export async function fetchFeed(
   url: string,
-  { etag, lastModified, proxy, retries = 3 }: FetchFeedOptions = {},
+  {
+    etag,
+    lastModified,
+    proxy = DEFAULT_PROXY,
+    retries = 3,
+  }: FetchFeedOptions = {},
 ): Promise<{
   status: number;
   etag?: string;
@@ -47,8 +60,7 @@ export async function fetchFeed(
   let lastError: unknown;
 
   while (attempt < retries) {
-    const target =
-      useProxy && proxy ? `${proxy}?url=${encodeURIComponent(url)}` : url;
+    const target = useProxy && proxy ? buildProxyUrl(proxy, url) : url;
     try {
       const res = await fetch(target, { headers });
       // Retry on server errors

--- a/src/lib/sync.ts
+++ b/src/lib/sync.ts
@@ -1,4 +1,4 @@
-import { fetchFeed } from './fetcher.ts';
+import { fetchFeed, DEFAULT_PROXY } from './fetcher.ts';
 import { parseFeed } from './feedParser.ts';
 import {
   articlesRepo,
@@ -11,7 +11,7 @@ let timer: ReturnType<typeof setInterval> | null = null;
 
 export async function syncFeedsOnce() {
   const proxySetting = await settingsRepo.get('proxyUrl');
-  const proxy = proxySetting?.value ?? null;
+  const proxy = proxySetting?.value || DEFAULT_PROXY;
   const feeds = await feedsRepo.all();
   for (const feed of feeds) {
     try {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -17,8 +17,10 @@ createRoot(document.getElementById('root')!).render(
 
 if ('serviceWorker' in navigator && import.meta.env.PROD) {
   window.addEventListener('load', () => {
-    navigator.serviceWorker.register('/sw.js').catch((err) => {
-      console.error('Service worker registration failed:', err);
-    });
+    navigator.serviceWorker
+      .register(`${import.meta.env.BASE_URL}sw.js`)
+      .catch((err) => {
+        console.error('Service worker registration failed:', err);
+      });
   });
 }


### PR DESCRIPTION
## Summary
- Register service worker using Vite base URL
- Default feed fetching to a CORS proxy and expose proxy setting
- Document default CORS proxy usage

## Testing
- `npm run lint`
- `npm run typecheck` *(fails: Missing script "typecheck")*
- `npm run format:check` *(fails: Missing script "format:check")*
- `npm test -- --coverage`
- `npm run e2e` *(fails: Missing script "e2e")*
- `npm run test:axe` *(fails: Missing script "test:axe")*
- `npm run lhci` *(fails: Missing script "lhci")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a1b561286c8332a2b2a4959b3370f9